### PR TITLE
Prometheus Terraform Migration

### DIFF
--- a/cloudwatch-exporter.tf
+++ b/cloudwatch-exporter.tf
@@ -1,0 +1,33 @@
+# Cloudwatch prometheus exporter
+# KIAM role creation
+# Ref: https://github.com/helm/charts/blob/master/stable/prometheus-cloudwatch-exporter/values.yaml
+
+resource "helm_release" "cloudwatch_exporter" {
+  #count     = terraform.workspace == local.live_workspace ? 1 : 0
+  count     = var.enable_cloudwatch_exporter ? 1 : 0
+
+
+
+  name      = "cloudwatch-exporter"
+  namespace = kubernetes_namespace.monitoring.id
+  chart     = "stable/prometheus-cloudwatch-exporter"
+
+  values = [
+    file("./resources/cloudwatch-exporter.yaml"),
+  ]
+
+  set {
+    name  = "aws.role"
+    value = aws_iam_role.cloudwatch_exporter.name
+  }
+
+  depends_on = [
+    var.dependence_deploy,
+    helm_release.prometheus_operator,
+  ]
+
+  lifecycle {
+    ignore_changes = [keyring]
+  }
+}
+

--- a/ecr-exporter.tf
+++ b/ecr-exporter.tf
@@ -1,0 +1,39 @@
+
+
+################
+# ECR Exporter #
+################
+
+resource "helm_release" "ecr_exporter" {
+  count      = var.enable_ecr_exporter ? 1 : 0
+
+  name       = "ecr-exporter"
+  namespace  = kubernetes_namespace.monitoring.id
+  chart      = "prometheus-ecr-exporter"
+  repository = data.helm_repository.cloud_platform.metadata[0].name
+
+  set {
+    name  = "serviceMonitor.enabled"
+    value = true
+  }
+
+  set {
+    name  = "aws.role"
+    value = aws_iam_role.ecr_exporter.name
+  }
+
+  set {
+    name  = "aws.region"
+    value = "eu-west-2"
+  }
+
+  depends_on = [
+    var.dependence_deploy,
+    helm_release.prometheus_operator,
+  ]
+
+  lifecycle {
+    ignore_changes = [keyring]
+  }
+}
+

--- a/kiam.tf
+++ b/kiam.tf
@@ -1,51 +1,51 @@
 
-##########
-# THANOS #
-##########
+# ##########
+# # THANOS #
+# ##########
 
-# This is to create a policy which allows Prometheus (thanos to be precise) to have a role to write to S3 without credentials
-data "aws_iam_policy_document" "monitoring_assume" {
-  statement {
-    actions = ["sts:AssumeRole"]
+# # This is to create a policy which allows Prometheus (thanos to be precise) to have a role to write to S3 without credentials
+# data "aws_iam_policy_document" "monitoring_assume" {
+#   statement {
+#     actions = ["sts:AssumeRole"]
 
-    principals {
-      type        = "AWS"
-      identifiers = [var.iam_role_nodes]
-    }
-  }
-}
+#     principals {
+#       type        = "AWS"
+#       identifiers = [var.iam_role_nodes]
+#     }
+#   }
+# }
 
-resource "aws_iam_role" "monitoring" {
-  name               = "monitoring.${data.terraform_remote_state.cluster.outputs.cluster_domain_name}"
-  assume_role_policy = data.aws_iam_policy_document.monitoring_assume.json
-}
+# resource "aws_iam_role" "monitoring" {
+#   name               = "monitoring.${data.terraform_remote_state.cluster.outputs.cluster_domain_name}"
+#   assume_role_policy = data.aws_iam_policy_document.monitoring_assume.json
+# }
 
-data "aws_iam_policy_document" "monitoring" {
+# data "aws_iam_policy_document" "monitoring" {
 
-  statement {
-    actions = [
-      "s3:ListBucket",
-      "s3:GetObject",
-      "s3:DeleteObject",
-      "s3:PutObject"
-    ]
+#   statement {
+#     actions = [
+#       "s3:ListBucket",
+#       "s3:GetObject",
+#       "s3:DeleteObject",
+#       "s3:PutObject"
+#     ]
 
-    # Bucket name is hardcoded because it hasn't been created with terraform
-    # files inside this repository. Once we are happy with the test we must: 
-    # 1. Create S3 bucket from the cp-environments repo (or maybe from here?)
-    # 2. Use the output (S3 bucket name) in this policy
-    resources = [
-      "arn:aws:s3:::cloud-platform-2b5483a8020c73862c69b87f44c398b8/*",
-      "arn:aws:s3:::cloud-platform-2b5483a8020c73862c69b87f44c398b8"
-    ]
-  }
-}
+#     # Bucket name is hardcoded because it hasn't been created with terraform
+#     # files inside this repository. Once we are happy with the test we must: 
+#     # 1. Create S3 bucket from the cp-environments repo (or maybe from here?)
+#     # 2. Use the output (S3 bucket name) in this policy
+#     resources = [
+#       "arn:aws:s3:::cloud-platform-2b5483a8020c73862c69b87f44c398b8/*",
+#       "arn:aws:s3:::cloud-platform-2b5483a8020c73862c69b87f44c398b8"
+#     ]
+#   }
+# }
 
-resource "aws_iam_role_policy" "monitoring" {
-  name   = "route53"
-  role   = aws_iam_role.monitoring.id
-  policy = data.aws_iam_policy_document.monitoring.json
-}
+# resource "aws_iam_role_policy" "monitoring" {
+#   name   = "route53"
+#   role   = aws_iam_role.monitoring.id
+#   policy = data.aws_iam_policy_document.monitoring.json
+# }
 
 ###########
 # Grafana #

--- a/kiam.tf
+++ b/kiam.tf
@@ -1,55 +1,6 @@
-
-# ##########
-# # THANOS #
-# ##########
-
-# # This is to create a policy which allows Prometheus (thanos to be precise) to have a role to write to S3 without credentials
-# data "aws_iam_policy_document" "monitoring_assume" {
-#   statement {
-#     actions = ["sts:AssumeRole"]
-
-#     principals {
-#       type        = "AWS"
-#       identifiers = [var.iam_role_nodes]
-#     }
-#   }
-# }
-
-# resource "aws_iam_role" "monitoring" {
-#   name               = "monitoring.${data.terraform_remote_state.cluster.outputs.cluster_domain_name}"
-#   assume_role_policy = data.aws_iam_policy_document.monitoring_assume.json
-# }
-
-# data "aws_iam_policy_document" "monitoring" {
-
-#   statement {
-#     actions = [
-#       "s3:ListBucket",
-#       "s3:GetObject",
-#       "s3:DeleteObject",
-#       "s3:PutObject"
-#     ]
-
-#     # Bucket name is hardcoded because it hasn't been created with terraform
-#     # files inside this repository. Once we are happy with the test we must: 
-#     # 1. Create S3 bucket from the cp-environments repo (or maybe from here?)
-#     # 2. Use the output (S3 bucket name) in this policy
-#     resources = [
-#       "arn:aws:s3:::cloud-platform-2b5483a8020c73862c69b87f44c398b8/*",
-#       "arn:aws:s3:::cloud-platform-2b5483a8020c73862c69b87f44c398b8"
-#     ]
-#   }
-# }
-
-# resource "aws_iam_role_policy" "monitoring" {
-#   name   = "route53"
-#   role   = aws_iam_role.monitoring.id
-#   policy = data.aws_iam_policy_document.monitoring.json
-# }
-
-###########
-# Grafana #
-###########
+######################
+# Grafana Cloudwatch #
+######################
 
 # Grafana datasource for cloudwatch
 # Ref: https://github.com/helm/charts/blob/master/stable/grafana/values.yaml
@@ -92,3 +43,79 @@ resource "aws_iam_role_policy" "grafana_datasource" {
   role   = aws_iam_role.grafana_datasource.id
   policy = data.aws_iam_policy_document.grafana_datasource.json
 }
+
+################
+# ECR Exporter #
+################
+
+data "aws_iam_policy_document" "ecr_exporter_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [var.iam_role_nodes]
+    }
+  }
+}
+
+resource "aws_iam_role" "ecr_exporter" {
+  name               = "ecr-exporter.${data.terraform_remote_state.cluster.outputs.cluster_domain_name}"
+  assume_role_policy = data.aws_iam_policy_document.ecr_exporter_assume.json
+}
+
+data "aws_iam_policy_document" "ecr_exporter" {
+  statement {
+    actions = [
+      "ecr:DescribeRepositories",
+      "ecr:ListImages",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "ecr_exporter" {
+  name   = "ecr-exporter"
+  role   = aws_iam_role.ecr_exporter.id
+  policy = data.aws_iam_policy_document.ecr_exporter.json
+}
+
+#######################
+# Cloudwatch Exporter #
+#######################
+
+data "aws_iam_policy_document" "cloudwatch_export_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [var.iam_role_nodes]
+    }
+  }
+}
+
+resource "aws_iam_role" "cloudwatch_exporter" {
+  name               = "cloudwatch.${data.terraform_remote_state.cluster.outputs.cluster_domain_name}"
+  assume_role_policy = data.aws_iam_policy_document.cloudwatch_export_assume.json
+}
+
+data "aws_iam_policy_document" "cloudwatch_exporter" {
+  statement {
+    actions = [
+      "cloudwatch:ListMetrics",
+      "cloudwatch:GetMetricStatistics",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "cloudwatch_exporter" {
+  name   = "cloudwatch-exporter"
+  role   = aws_iam_role.cloudwatch_exporter.id
+  policy = data.aws_iam_policy_document.cloudwatch_exporter.json
+}
+
+

--- a/kiam.tf
+++ b/kiam.tf
@@ -1,0 +1,94 @@
+
+##########
+# THANOS #
+##########
+
+# This is to create a policy which allows Prometheus (thanos to be precise) to have a role to write to S3 without credentials
+data "aws_iam_policy_document" "monitoring_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [var.iam_role_nodes]
+    }
+  }
+}
+
+resource "aws_iam_role" "monitoring" {
+  name               = "monitoring.${data.terraform_remote_state.cluster.outputs.cluster_domain_name}"
+  assume_role_policy = data.aws_iam_policy_document.monitoring_assume.json
+}
+
+data "aws_iam_policy_document" "monitoring" {
+
+  statement {
+    actions = [
+      "s3:ListBucket",
+      "s3:GetObject",
+      "s3:DeleteObject",
+      "s3:PutObject"
+    ]
+
+    # Bucket name is hardcoded because it hasn't been created with terraform
+    # files inside this repository. Once we are happy with the test we must: 
+    # 1. Create S3 bucket from the cp-environments repo (or maybe from here?)
+    # 2. Use the output (S3 bucket name) in this policy
+    resources = [
+      "arn:aws:s3:::cloud-platform-2b5483a8020c73862c69b87f44c398b8/*",
+      "arn:aws:s3:::cloud-platform-2b5483a8020c73862c69b87f44c398b8"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "monitoring" {
+  name   = "route53"
+  role   = aws_iam_role.monitoring.id
+  policy = data.aws_iam_policy_document.monitoring.json
+}
+
+###########
+# Grafana #
+###########
+
+# Grafana datasource for cloudwatch
+# Ref: https://github.com/helm/charts/blob/master/stable/grafana/values.yaml
+
+data "aws_iam_policy_document" "grafana_datasource_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "AWS"
+      identifiers = [var.iam_role_nodes]
+    }
+  }
+}
+
+resource "aws_iam_role" "grafana_datasource" {
+  name               = "datasource.${data.terraform_remote_state.cluster.outputs.cluster_domain_name}"
+  assume_role_policy = data.aws_iam_policy_document.grafana_datasource_assume.json
+}
+
+# Minimal policy permissions 
+# Ref: https://grafana.com/docs/grafana/latest/features/datasources/cloudwatch/#iam-policies
+
+data "aws_iam_policy_document" "grafana_datasource" {
+  statement {
+    actions = [
+      "cloudwatch:ListMetrics",
+      "cloudwatch:GetMetricStatistics",
+      "cloudwatch:GetMetricData",
+    ]
+    resources = ["*"]
+  }
+  statement {
+    actions   = ["sts:AssumeRole"]
+    resources = [aws_iam_role.grafana_datasource.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "grafana_datasource" {
+  name   = "grafana-datasource"
+  role   = aws_iam_role.grafana_datasource.id
+  policy = data.aws_iam_policy_document.grafana_datasource.json
+}

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,26 @@
+
+locals {
+  live_workspace = "live-1"
+  live_domain    = "cloud-platform.service.justice.gov.uk"
+
+  alertmanager_ingress = terraform.workspace == local.live_workspace ? format("%s.%s", "https://alertmanager", local.live_domain) : format(
+    "%s.%s",
+    "https://alertmanager.apps",
+    data.terraform_remote_state.cluster.outputs.cluster_domain_name,
+  )
+  grafana_ingress = terraform.workspace == local.live_workspace ? format("%s.%s", "grafana", local.live_domain) : format(
+    "%s.%s",
+    "grafana.apps",
+    data.terraform_remote_state.cluster.outputs.cluster_domain_name,
+  )
+  grafana_root = terraform.workspace == local.live_workspace ? format("%s.%s", "https://grafana", local.live_domain) : format(
+    "%s.%s",
+    "https://grafana.apps",
+    data.terraform_remote_state.cluster.outputs.cluster_domain_name,
+  )
+  prometheus_ingress = terraform.workspace == local.live_workspace ? format("%s.%s", "https://prometheus", local.live_domain) : format(
+    "%s.%s",
+    "https://prometheus.apps",
+    data.terraform_remote_state.cluster.outputs.cluster_domain_name,
+  )
+}

--- a/main.tf
+++ b/main.tf
@@ -9,3 +9,8 @@ data "terraform_remote_state" "cluster" {
     profile = "moj-cp"
   }
 }
+
+data "helm_repository" "cloud_platform" {
+  name = "cloud-platform"
+  url  = "https://ministryofjustice.github.io/cloud-platform-helm-charts"
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,11 @@
+
+data "terraform_remote_state" "cluster" {
+  backend = "s3"
+
+  config = {
+    bucket  = "cloud-platform-terraform-state"
+    region  = "eu-west-1"
+    key     = "cloud-platform/${terraform.workspace}/terraform.tfstate"
+    profile = "moj-cp"
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,4 @@
+
+output "helm_prometheus_operator_status" {
+    value = helm_release.prometheus_operator.status
+}

--- a/prometheus.tf
+++ b/prometheus.tf
@@ -125,7 +125,6 @@ resource "helm_release" "prometheus_operator" {
     random_password        = random_id.password.hex
     grafana_pod_annotation = aws_iam_role.grafana_datasource.name
     grafana_assumerolearn  = aws_iam_role.grafana_datasource.arn
-    monitoring_aws_role    = aws_iam_role.monitoring.name
   })]
 
   # Depends on Helm being installed

--- a/prometheus.tf
+++ b/prometheus.tf
@@ -1,0 +1,236 @@
+
+# Namespace creation
+resource "kubernetes_namespace" "monitoring" {
+  metadata {
+    name = "monitoring"
+
+    labels = {
+      "component" = "monitoring"
+    }
+
+    annotations = {
+      "cloud-platform.justice.gov.uk/application"                = "Monitoring"
+      "cloud-platform.justice.gov.uk/business-unit"              = "cloud-platform"
+      "cloud-platform.justice.gov.uk/owner"                      = "Cloud Platform: platforms@digital.justice.gov.uk"
+      "cloud-platform.justice.gov.uk/source-code"                = "https://github.com/ministryofjustice/cloud-platform-infrastructure"
+      "iam.amazonaws.com/permitted"                              = ".*"
+      "cloud-platform.justice.gov.uk/can-tolerate-master-taints" = "true"
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [metadata]
+  }
+}
+
+# Grafana secrets
+resource "kubernetes_secret" "grafana_secret" {
+  metadata {
+    name      = "grafana-env"
+    namespace = kubernetes_namespace.monitoring.id
+  }
+
+  data = {
+    GF_AUTH_GENERIC_OAUTH_CLIENT_ID     = data.terraform_remote_state.cluster.outputs.oidc_components_client_id
+    GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET = data.terraform_remote_state.cluster.outputs.oidc_components_client_secret
+    GF_AUTH_GENERIC_OAUTH_AUTH_URL      = "${data.terraform_remote_state.cluster.outputs.oidc_issuer_url}authorize"
+    GF_AUTH_GENERIC_OAUTH_TOKEN_URL     = "${data.terraform_remote_state.cluster.outputs.oidc_issuer_url}oauth/token"
+    GF_AUTH_GENERIC_OAUTH_API_URL       = "${data.terraform_remote_state.cluster.outputs.oidc_issuer_url}userinfo"
+  }
+
+  type = "Opaque"
+}
+
+resource "random_id" "username" {
+  byte_length = 8
+}
+
+resource "random_id" "password" {
+  byte_length = 8
+}
+
+data "template_file" "alertmanager_routes" {
+  count = length(var.alertmanager_slack_receivers)
+
+  template = <<EOS
+- match:
+    severity: info-$${severity}
+  receiver: slack-info-$${severity}
+  continue: true
+- match:
+    severity: $${severity}
+  receiver: slack-$${severity}
+EOS
+
+
+  vars = var.alertmanager_slack_receivers[count.index]
+}
+
+data "template_file" "alertmanager_receivers" {
+  count = length(var.alertmanager_slack_receivers)
+
+  template = <<EOS
+- name: 'slack-$${severity}'
+  slack_configs:
+  - api_url: "$${webhook}"
+    channel: "$${channel}"
+    send_resolved: True
+    title: '{{ template "slack.cp.title" . }}'
+    text: '{{ template "slack.cp.text" . }}'
+    footer: ${local.alertmanager_ingress}
+    actions:
+    - type: button
+      text: 'Runbook :blue_book:'
+      url: '{{ (index .Alerts 0).Annotations.runbook_url }}'
+    - type: button
+      text: 'Query :mag:'
+      url: '{{ (index .Alerts 0).GeneratorURL }}'
+    - type: button
+      text: 'Silence :no_bell:'
+      url: '{{ template "__alert_silence_link" . }}'
+- name: 'slack-info-$${severity}'
+  slack_configs:
+  - api_url: "$${webhook}"
+    channel: "$${channel}"
+    send_resolved: False
+    title: '{{ template "slack.cp.title" . }}'
+    text: '{{ template "slack.cp.text" . }}'
+    color: 'good'
+    footer: ${local.alertmanager_ingress}
+    actions:
+    - type: button
+      text: 'Query :mag:'
+      url: '{{ (index .Alerts 0).GeneratorURL }}'
+EOS
+
+
+  vars = var.alertmanager_slack_receivers[count.index]
+}
+
+resource "helm_release" "prometheus_operator" {
+  name      = "prometheus-operator"
+  chart     = "stable/prometheus-operator"
+  namespace = kubernetes_namespace.monitoring.id
+  version   = "8.7.0"
+
+  values = [templatefile("${path.module}/templates/prometheus-operator.yaml.tpl", {
+    alertmanager_ingress   = local.alertmanager_ingress
+    grafana_ingress        = local.grafana_ingress
+    grafana_root           = local.grafana_root
+    pagerduty_config       = var.pagerduty_config
+    alertmanager_routes    = "${join("", data.template_file.alertmanager_routes.*.rendered)}"
+    alertmanager_receivers = "${join("", data.template_file.alertmanager_receivers.*.rendered)}"
+    prometheus_ingress     = local.prometheus_ingress
+    random_username        = random_id.username.hex
+    random_password        = random_id.password.hex
+    grafana_pod_annotation = aws_iam_role.grafana_datasource.name
+    grafana_assumerolearn  = aws_iam_role.grafana_datasource.arn
+    monitoring_aws_role    = aws_iam_role.monitoring.name
+  })]
+
+  # Depends on Helm being installed
+  depends_on = [
+    var.dependence_deploy,
+    var.dependence_opa,
+    kubernetes_secret.grafana_secret,
+  ]
+
+  provisioner "local-exec" {
+    command = "kubectl apply -n monitoring -f ${path.module}/resources/prometheusrule-alerts/"
+  }
+
+  # Delete Prometheus leftovers
+  # Ref: https://github.com/coreos/prometheus-operator#removal
+  provisioner "local-exec" {
+    when    = destroy
+    command = "kubectl delete svc -l k8s-app=kubelet -n kube-system"
+  }
+
+  lifecycle {
+    ignore_changes = [keyring]
+  }
+}
+
+# Alertmanager and Prometheus proxy
+# Ref: https://github.com/evry/docker-oidc-proxy
+resource "random_id" "session_secret" {
+  byte_length = 16
+}
+
+data "template_file" "prometheus_proxy" {
+  template = file("${path.module}/templates/oauth2-proxy.yaml.tpl")
+
+  vars = {
+    upstream = "http://prometheus-operator-prometheus:9090"
+    hostname = terraform.workspace == local.live_workspace ? format("%s.%s", "prometheus", local.live_domain) : format(
+      "%s.%s",
+      "prometheus.apps",
+      data.terraform_remote_state.cluster.outputs.cluster_domain_name,
+    )
+    exclude_paths = "^/-/healthy$"
+    issuer_url    = data.terraform_remote_state.cluster.outputs.oidc_issuer_url
+    client_id     = data.terraform_remote_state.cluster.outputs.oidc_components_client_id
+    client_secret = data.terraform_remote_state.cluster.outputs.oidc_components_client_secret
+    cookie_secret = random_id.session_secret.b64_std
+  }
+}
+
+resource "helm_release" "prometheus_proxy" {
+  name      = "prometheus-proxy"
+  namespace = kubernetes_namespace.monitoring.id
+  chart     = "stable/oauth2-proxy"
+  version   = "0.9.1"
+
+  values = [
+    data.template_file.prometheus_proxy.rendered,
+  ]
+
+  depends_on = [
+    var.dependence_deploy,
+    var.dependence_opa,
+    random_id.session_secret,
+  ]
+
+  lifecycle {
+    ignore_changes = [keyring]
+  }
+}
+
+data "template_file" "alertmanager_proxy" {
+  template = file("${path.module}/templates/oauth2-proxy.yaml.tpl")
+
+  vars = {
+    upstream = "http://prometheus-operator-alertmanager:9093"
+    hostname = terraform.workspace == local.live_workspace ? format("%s.%s", "alertmanager", local.live_domain) : format(
+      "%s.%s",
+      "alertmanager.apps",
+      data.terraform_remote_state.cluster.outputs.cluster_domain_name,
+    )
+    exclude_paths = "^/-/healthy$"
+    issuer_url    = data.terraform_remote_state.cluster.outputs.oidc_issuer_url
+    client_id     = data.terraform_remote_state.cluster.outputs.oidc_components_client_id
+    client_secret = data.terraform_remote_state.cluster.outputs.oidc_components_client_secret
+    cookie_secret = random_id.session_secret.b64_std
+  }
+}
+
+resource "helm_release" "alertmanager_proxy" {
+  name      = "alertmanager-proxy"
+  namespace = "monitoring"
+  chart     = "stable/oauth2-proxy"
+  version   = "0.9.1"
+
+  values = [
+    data.template_file.alertmanager_proxy.rendered,
+  ]
+
+  depends_on = [
+    var.dependence_deploy,
+    var.dependence_opa,
+    random_id.session_secret,
+  ]
+
+  lifecycle {
+    ignore_changes = [keyring]
+  }
+}

--- a/resources/prometheusrule-alerts/Custom-Alerts.md
+++ b/resources/prometheusrule-alerts/Custom-Alerts.md
@@ -1,0 +1,472 @@
+# Custom Alarms
+
+## Node-Disk-Space-Warning
+```
+Node-Disk-Space-Warning
+Severity: warning
+```
+This alert is triggered when a node will run out of disk space in the next 6 hours at the current usage rate.
+
+Expression:
+```
+expr: predict_linear(node_filesystem_free[6h], 3600 * 24) < 0
+for: 30m
+```
+### Action
+
+Run the following command to confirm disk shortage on a node:
+`kubectl describe nodes`
+
+You are looking for the boolean condition of:
+`OutOfDiskSpace`
+
+Please read the documentation from [Kubernetes](https://github.com/kubernetes/kops/blob/master/docs/instance_groups.md#changing-the-root-volume-size-or-type) regarding the best possible actions.
+
+[Changing the root volume size or type](https://github.com/kubernetes/kops/blob/master/docs/instance_groups.md#changing-the-root-volume-size-or-type)
+[Resize an instance group](https://github.com/kubernetes/kops/blob/master/docs/instance_groups.md#resize-an-instance-group)
+[Change the instance type in an instance group](https://github.com/kubernetes/kops/blob/master/docs/instance_groups.md#change-the-instance-type-in-an-instance-group)
+
+## Node-Disk-Space-Low
+```
+Node-Disk-Space-Low
+Severity: warning
+```
+This alert is triggered when a node has less than 10% disk space for 30 minutes. 
+
+Expression:
+```
+expr: ((node_filesystem_avail_bytes * 100) / node_filesystem_size_bytes) < 10
+for: 30m
+```
+### Action
+
+Run the following command to confirm disk shortage on a node:
+`kubectl describe nodes`
+
+You are looking for the boolean condition of:
+`OutOfDiskSpace`
+
+Please read the documentation from [Kubernetes](https://github.com/kubernetes/kops/blob/master/docs/instance_groups.md#changing-the-root-volume-size-or-type) regarding the best possible actions.
+
+[Changing the root volume size or type](https://github.com/kubernetes/kops/blob/master/docs/instance_groups.md#changing-the-root-volume-size-or-type)
+[Resize an instance group](https://github.com/kubernetes/kops/blob/master/docs/instance_groups.md#resize-an-instance-group)
+[Change the instance type in an instance group](https://github.com/kubernetes/kops/blob/master/docs/instance_groups.md#change-the-instance-type-in-an-instance-group)
+
+## Memory-High
+```
+Memory-High
+Severity: warning
+```
+This alert is triggered when the memory usage is at or over 95% for 5 minutes
+
+Expression:
+```
+expr: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / (node_memory_MemTotal_bytes) * 100 > 80
+for: 5m
+```
+### Action
+
+Run the following to get a breakdown of memory usage:
+```bash
+kubectl describe node <node_name>
+```
+
+Please read the Kubernetes documentation of the [Meaning of Memory](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory)
+
+You can [set Memory limits](https://kubernetes.io/docs/tasks/configure-pod-container/assign-memory-resource/) to pods and containers, as by default - pods run with unbounded memory limits.
+
+Limits can also be set on a [Namespace](https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/)
+
+## Memory-Critical
+```
+Memory-Critical
+Severity: critical
+```
+This alert is triggered when the memory usage is at or over 95% for 5 minutes
+
+Expression:
+```
+expr: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / (node_memory_MemTotal_bytes) * 100 > 95
+for: 5m
+```
+### Action
+
+Run the following to get a breakdown of memory usage:
+```bash
+kubectl describe node <node_name>
+```
+Please read the Kubernetes documentation of the [Meaning of Memory](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory)
+
+You can [set Memory limits](https://kubernetes.io/docs/tasks/configure-pod-container/assign-memory-resource/) to pods and containers, as by default - pods run with unbounded memory limits.
+
+Limits can also be set on a [Namespace](https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/)
+
+## CPU-High
+```
+CPU-High
+Severity: warning
+```
+This alert is triggered when the CPU for a node is running at or over 80% for 5 minutes
+
+Expression:
+```
+expr: 100 - (avg by(instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 80
+for: 5m
+```
+### Action
+
+Run the following to get a breakdown of CPU usage:
+```bash
+kubectl describe node <node_name>
+```
+
+Please read the Kubernetes documentation of the [Meaning of CPU](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu)
+
+You can [set CPU limits](https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/) to pods and containers, as by default - pods run with unbounded CPU limits.
+
+Limits can also be set on a [Namespace](https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace/)
+
+
+## CPU-Critical
+```
+CPU-Critical
+Severity: critical
+```
+This alert is triggered when the CPU for a node is running at or over 95% for 5 minutes
+
+Expression:
+```
+expr: 100 - (avg by(instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 95
+for: 5m
+```
+### Action
+
+Run the following to get a breakdown of CPU usage:
+```bash
+kubectl describe node <node_name>
+```
+
+Please read the Kubernetes documentation of the [Meaning of CPU](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu)
+
+You can [set CPU limits](https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/) to pods and containers, as by default - pods run with unbounded CPU limits.
+
+Limits can also be set on a [Namespace](https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace/)
+
+## KubeDNSDown
+
+```
+KubeDNSDown
+Severity: critical
+```
+This alert is triggered when KubeDNS is not present on the cluster for 5 minutes
+
+Expression:
+```
+absent(up{job="kube-dns"} == 1)
+for: 5m
+```
+
+### Action
+
+Run the following command to confirm kube-dns is in the cluster:
+
+`$ kubectl get deployments -n kube-system`
+
+`$ kubectl get pods -n kube-system`
+
+You are looking for the `kube-dns` deployment and pod.
+
+If `kube-dns` pod(s) are present but failing, describe the pod to check events and check the logs:
+
+```
+$ kubectl get pods -n kube-system
+$ kubectl describe pod <kube-dns-container> -n kube-system
+$ kubectl logs <kube-dns-container> -n kube-system`
+```
+If the `kube-dns` pod(s) are missing, check to see if the `kube-dns` deployment is present. If the deployment is missing, apply the `kube-dns` [deployment template](https://github.com/kubernetes/kops/blob/release-1.9/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template) to the kube-system namespace.
+
+Before applying, replace all templated syntax from the file with the cluster information.
+
+`$ kubectl apply -f k8s-1.6.yaml.template -n kube-system`
+
+**Note**: The template is for Kops 1.9.
+
+## External-DNSDown
+
+```
+External-DNSDown
+Severity: warning
+```
+This alert is triggered when '0' external-dns pods are running for longer than 5 minutes.
+
+Expression:
+```
+kube_deployment_status_replicas_available{deployment="external-dns"} == 0
+for: 5m
+```
+### Action
+
+Check if the external-dns pod is running. If so, describe the pod to check events and check the logs:
+
+```
+$ kubectl get pods -n kube-system
+$ kubectl describe pod <external-dns-container> -n kube-system
+$ kubectl logs <external-dns-container> -n kube-system
+```
+
+If the external-dns is not present, check the helm deployment status to see if all of the resources are running:
+
+`$ helm status external-dns`
+
+Check to see if the external-dns pod is running in the `kube-system` namespace:
+
+`$ kubectl get pods -n kube-system`
+
+## NginxIngressPodDown
+
+```
+NginxIngressPodDown
+Severity: warning
+```
+This alert is triggered when less than 6 nginx-ingress pods are running for 5 minutes.
+
+Expression:
+```
+kube_deployment_status_replicas_available{deployment="nginx-ingress-controller"} < 6
+for: 5m
+```
+
+### Action
+
+Check how many nginx-ingress pods are running. There should be at least 6 with the status `Running`.
+
+`$ kubectl get pods -n nginx-controllers`
+
+If a container is failing, describe the pod to check if there are any failures. If nothing is obvious, check the logs:
+
+```
+$ kubectl describe pod <nginx-ingress-container> -n nginx-controllers
+$ kubectl logs <nginx-ingress-container> -n nginx-controllers
+```
+
+If the pod is missing or you think it's possible to scale up, do the following:
+
+`$ kubectl scale --current-replicas=2 --replicas=3 deployment/nginx-ingress-controller -n nginx-controllers`
+
+The above example shows that 2 nginx-ingress pods are running and we need 3. The command will increase the number of pods.
+
+## NginxIngressDown
+
+```
+NginxIngressDown
+Severity: critical
+```
+
+This alert is triggered when no nginx-ingress pods have been running for 5 minutes.
+
+Expression:
+```
+kube_deployment_status_replicas_available{deployment="nginx-ingress-controller"} == 0
+for: 5m
+```
+
+### Action
+
+Check why the nginx-ingress pods are failing:
+
+```
+$ kubectl get pods -n nginx-controllers
+$ kubectl describe pod <nginx-ingress-container> -n nginx-controllers
+$ kubectl logs <nginx-ingress-container> -n nginx-controllers
+```
+
+## Root Volume Utilisation - High
+
+```
+RootVolUtilisation-High
+Severity: warning
+```
+This alert is triggered when the root volume has 85% of the capacity used
+
+Expression:
+```
+expr: (node_filesystem_size_bytes {mountpoint="/"} - node_filesystem_avail_bytes {mountpoint="/"} ) / (node_filesystem_size_bytes {mountpoint="/"} ) * 100 >85
+for: 5m
+```
+
+### Action
+
+Run the following command to get a list of nodes and confirm the node with the issue is in the expected cluster:
+
+`$ kubectl get nodes`
+
+`$ kubectl describe node <node_name>`
+
+Look at the 'Conditions' Section for possible more info such as a disk space issue on the node is general and not just root.
+
+SSH into the node and run `lsblk` and `df -h` to list the block devices attached to the instance and disk usage.
+
+The following command can be used to search files by size to help identify/delete/backup files that may be causing the disk to fill up:
+
+```bash
+sudo find / -type f -size +100M -exec ls -lh {} \;
+```
+
+If the file system needs resizing, please follow the [offical AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/recognize-expanded-volume-linux.html) to expand the volume
+
+## Root Volume Utilisation - Critical
+
+```
+RootVolUtilisation-Critical
+Severity: critical
+```
+This alert is triggered when the root volume has 95% of the capacity used
+
+Expression:
+```
+expr: (node_filesystem_size_bytes {mountpoint="/"} - node_filesystem_avail_bytes {mountpoint="/"} ) / (node_filesystem_size_bytes {mountpoint="/"} ) * 100 >95
+for: 1m
+```
+
+### Action
+
+Run the following command to get a list of nodes and confirm the node with the issue is in the expected cluster:
+
+`$ kubectl get nodes`
+
+`$ kubectl describe node <node_name>`
+
+Look at the 'Conditions' Section for possible more info such as a disk space issue on the node is general and not just root.
+
+SSH into the node and run `lsblk` and `df -h` to list the block devices attached to the instance and disk usage.
+
+The following command can be used to search files by size to help identify/delete/backup files that may be causing the disk to fill up:
+
+```bash
+sudo find / -type f -size +100M -exec ls -lh {} \;
+```
+
+If the file system needs resizing, please follow the [offical AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/recognize-expanded-volume-linux.html) to expand the volume
+
+## Curator Cronjob Failure
+
+```
+CuratorCronjobFailure
+Severity: warning
+```
+
+This alert is triggered when the curator cronjob fails.
+
+Expression:
+```
+kube_job_status_failed{job-name=~"elasticsearch-curator-cronjob.+"} > 0
+for: 1h
+```
+
+### Action
+
+Check why the curator cronjob is failing:
+
+```
+$ kubectl get cronjobs -n logging
+$ kubectl describe cronjob <cronjob-name> -n logging
+$ kubectl logs <cronjob-name> -n logging
+```
+
+The following links have more information on [Kubernetes Cronjobs](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) and [Kubernetes Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/)
+
+## Curator Cronjob Running
+
+```
+CuratorCronJobRunning
+Severity: warning
+```
+
+This alert is triggered when the curator cronjob is running longer than 1 hour
+
+Expression:
+```
+time() - kube_cronjob_next_schedule_time {cronjob="elasticsearch-curator-cronjob"} > 3600
+for: 1h
+```
+
+### Action
+
+Check why the curator cronjob is running for over 1 hour:
+
+```
+$ kubectl get cronjobs -n logging
+$ kubectl describe cronjob <cronjob-name> -n logging
+$ kubectl logs <cronjob-name> -n logging
+```
+
+The following links have more information on [Kubernetes Cronjobs](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) and [Kubernetes Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/)
+
+## Curator Job Completion
+
+```
+CuratorJobCompletion
+Severity: warning
+```
+
+This alert is triggered when job completion is taking longer than 1 hour to complete curator cronjob
+
+Expression:
+```
+kube_job_spec_completions - kube_job_status_succeeded {job_name=~"elasticsearch-curator-cronjob.+"} > 0      
+for: 1h
+```
+
+### Action
+
+Check why the job completion for curator cronjob is running for over 1 hour:
+
+```
+$ kubectl get cronjobs -n logging
+$ kubectl describe cronjob <cronjob-name> -n logging
+$ kubectl logs <cronjob-name> -n logging
+```
+
+The following links have more information on [Kubernetes Cronjobs](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) and [Kubernetes Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/)
+
+## Nginx Config Reload Failure
+
+```
+NginxConfigReloadFailure
+Severity: Critical
+```
+
+This alert is triggered when the nginx config fails to reload on an ingress-controller pod.
+
+Expression:
+```
+nginx_ingress_controller_config_last_reload_successful == 0
+```
+
+### Action
+
+Check why nginx config is not able to reload using the below:
+
+The following two [`stern`](https://github.com/wercker/stern) commands can be run to confirm config is not reloading and for any errors marked as `[emerg]` which means the system is in an unusable state and requires immediate attention.
+
+```
+stern --namespace ingress-controllers nginx-ingress-acme-controller | grep "Unexpected failure reloading the backend"
+stern --namespace ingress-controllers nginx-ingress-acme-controller | grep emerg
+```
+
+You can also run the following query on Kibana to check for the error:
+
+`kubernetes.namespace_name:event-router emerg`
+
+#### Nginx Error Log Severity Levels
+
+The are a number of severity levels that can be defined in the error_log. The following is a list of all severity levels: 
+
++ debug - Useful debugging information to help determine where the problem lies.
++ info - Informational messages that aren’t necessary to read but may be good to know.
++ notice - Something normal happened that is worth noting.
++ warn - Something unexpected happened, however is not a cause for concern.
++ error - Something was unsuccessful.
++ crit - There are problems that need to be critically addressed.
++ alert - Prompt action is required.
++ emerg - The system is in an unusable state and requires immediate attention.

--- a/resources/prometheusrule-alerts/application-alerts.yaml
+++ b/resources/prometheusrule-alerts/application-alerts.yaml
@@ -1,0 +1,295 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: prometheus-operator
+    role: alert-rules
+  name: prometheus-operator-custom-kubernetes-apps.rules
+spec:
+  groups:
+  - name: kubernetes-apps
+    rules:
+    - alert: KubeQuota-Exceeded
+      annotations:
+        message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value
+          }}% of its {{ $labels.resource }} quota.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
+      expr: |-
+        100 * kube_resourcequota{job="kube-state-metrics", type="used"} 
+        * on (namespace)
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"}
+        / ignoring(instance, job, type)
+        (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0)
+        > 90
+      for: 15m
+      labels:
+        severity: warning
+    - alert: KubePodCrashLooping
+      annotations:
+        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
+          }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping
+      expr: |-
+        rate(kube_pod_container_status_restarts_total{job="kube-state-metrics"}[15m]) 
+        * on (namespace)
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"}
+        * 60 * 5 > 0
+      for: 1h
+      labels:
+        severity: warning
+    - alert: KubePodNotReady
+      annotations:
+        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
+          state for longer than an hour.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
+      expr: |-
+        sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown"}) 
+        * on (namespace) 
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"} 
+        > 0
+      for: 1h
+      labels:
+        severity: warning
+    - alert: KubeDeploymentGenerationMismatch
+      annotations:
+        message: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
+          }} does not match, this indicates that the Deployment has failed but has
+          not been rolled back.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentgenerationmismatch
+      expr: |-
+        kube_deployment_status_observed_generation{job="kube-state-metrics"}
+        * on (namespace)
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"} 
+        !=
+        kube_deployment_metadata_generation{job="kube-state-metrics"}
+      for: 15m
+      labels:
+        severity: warning
+    - alert: KubeDeploymentReplicasMismatch
+      annotations:
+        message: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not
+          matched the expected number of replicas for longer than an hour.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentreplicasmismatch
+      expr: |-
+        kube_deployment_spec_replicas{job="kube-state-metrics"} 
+        * on (namespace)
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"} 
+        != kube_deployment_status_replicas_available{job="kube-state-metrics"}
+      for: 1h
+      labels:
+        severity: warning
+    - alert: KubeStatefulSetReplicasMismatch
+      annotations:
+        message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has
+          not matched the expected number of replicas for longer than 15 minutes.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetreplicasmismatch
+      expr: |-
+        kube_statefulset_status_replicas_ready{job="kube-state-metrics"}
+        * on (namespace)
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"}
+        !=
+        kube_statefulset_status_replicas{job="kube-state-metrics"}
+      for: 15m
+      labels:
+        severity: warning
+    - alert: KubeStatefulSetGenerationMismatch
+      annotations:
+        message: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
+          }} does not match, this indicates that the StatefulSet has failed but has
+          not been rolled back.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetgenerationmismatch
+      expr: |-
+        kube_statefulset_status_observed_generation{job="kube-state-metrics"}        
+        * on (namespace)
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"}
+        !=
+        kube_statefulset_metadata_generation{job="kube-state-metrics"}
+      for: 15m
+      labels:
+        severity: critical
+    - alert: KubeStatefulSetUpdateNotRolledOut
+      annotations:
+        message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} update
+          has not been rolled out.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetupdatenotrolledout
+      expr: |-
+        max without (revision) (
+          kube_statefulset_status_current_revision{job="kube-state-metrics"}
+          * on (namespace)
+          group_left() 
+          kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"}
+            unless
+          kube_statefulset_status_update_revision{job="kube-state-metrics"}
+        )
+          *
+        (
+          kube_statefulset_replicas{job="kube-state-metrics"}
+          * on (namespace)
+          group_left() 
+          kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"}
+          !=
+          kube_statefulset_status_replicas_updated{job="kube-state-metrics"}
+        )  
+      for: 15m
+      labels:
+        severity: warning
+    - alert: KubeDaemonSetRolloutStuck
+      annotations:
+        message: Only {{ $value }}% of the desired Pods of DaemonSet {{ $labels.namespace
+          }}/{{ $labels.daemonset }} are scheduled and ready.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetrolloutstuck
+      expr: |-
+        kube_daemonset_status_number_ready{job="kube-state-metrics"}
+        * on (namespace)
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"}
+        /
+        kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"} * 100 < 100
+      for: 15m
+      labels:
+        severity: warning
+    - alert: KubeDaemonSetNotScheduled
+      annotations:
+        message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset
+          }} are not scheduled.'
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetnotscheduled
+      expr: |-
+        kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"}     
+        * on (namespace)
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"}
+        -
+        kube_daemonset_status_current_number_scheduled{job="kube-state-metrics"} > 0 
+      for: 10m
+      labels:
+        severity: warning
+    - alert: KubeDaemonSetMisScheduled
+      annotations:
+        message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset
+          }} are running where they are not supposed to run.'
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetmisscheduled
+      expr: |-
+        kube_daemonset_status_number_misscheduled{job="kube-state-metrics"} 
+        * on (namespace)
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"} 
+        > 0
+      for: 10m
+      labels:
+        severity: warning
+    - alert: KubeCronJobRunning
+      annotations:
+        message: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more
+          than 1h to complete.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecronjobrunning
+      expr: |-
+        time() - kube_cronjob_next_schedule_time{job="kube-state-metrics"} 
+        * on (namespace)
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"} 
+        > 3600
+      for: 1h
+      labels:
+        severity: warning
+    - alert: KubeJobCompletion
+      annotations:
+        message: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more
+          than one hour to complete.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobcompletion
+      expr: |-
+        kube_job_spec_completions{job="kube-state-metrics"} - kube_job_status_succeeded{job="kube-state-metrics"} 
+        * on (namespace)
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"} 
+        > 0
+      for: 1h
+      labels:
+        severity: warning
+    - alert: KubeJobFailed
+      annotations:
+        message: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed
+      expr: |-
+        kube_job_status_failed{job="kube-state-metrics"}  
+        * on (namespace)
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"} 
+        > 0
+      for: 1h
+      labels:
+        severity: warning
+    - alert: TargetDown
+      annotations:
+        message: '{{ $value }}% of the {{ $labels.job }} targets are down.'
+      expr: |-
+        100 * (count(up == 0) BY (job) / count(up) BY (job)) 
+        * on (namespace)
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"} 
+        > 10
+      for: 10m
+      labels:
+        severity: warning
+    - alert: KubePersistentVolumeFullInFourDays-Low
+      annotations:
+        message: Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is expected to fill up within four days. Currently {{ printf "%0.2f" $value }} is available.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefullinfourdays
+      expr: |-
+        100 * (
+          kubelet_volume_stats_available_bytes{job="kubelet"}
+            /
+          kubelet_volume_stats_capacity_bytes{job="kubelet"}
+        ) < 15
+        and
+        predict_linear(kubelet_volume_stats_available_bytes{job="kubelet"}[6h], 4 * 24 * 3600) < 0
+      for: 5m
+      labels:
+        severity: warning
+    - alert: VeleroBackupPartialFailure-velero-allnamespacebackup
+      annotations:
+        message: A Velero backup partial failure in past 3 hours - velero-allnamespacebackup
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md
+      expr: sum(increase(velero_backup_partial_failure_total{schedule="velero-allnamespacebackup"}[3h])) > 0
+      for: 1m
+      labels:
+        severity: warning
+    - alert: VeleroBackupFailure-velero-allnamespacebackup
+      annotations:
+        message: A Velero backup failure in past 3 hours - velero-allnamespacebackup
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md
+      expr: sum(increase(velero_backup_failure_total{schedule="velero-allnamespacebackup"}[3h])) > 0
+      for: 1m
+      labels:
+        severity: warning
+    - alert: VeleroBackupNotSuccessfulForOverFourHours-velero-allnamespacebackup
+      annotations:
+        message: The Velero backup schedule for AllNamespaceBackup does not have a successful timestamp for over 4 hours
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md
+      expr: (time() - velero_backup_last_successful_timestamp{schedule="velero-allnamespacebackup"}) / 60 / 60 > 4
+      for: 1m
+      labels:
+        severity: warning
+    - alert: VeleroBackupPartialFailure
+      annotations:
+        message: A Velero backup partial failure notification
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md
+      expr: sum(increase(velero_backup_partial_failure_total[2m])) > 0
+      for: 1m
+      labels:
+        severity: info-warning
+    - alert: VeleroBackupFailure
+      annotations:
+        message: A Velero backup failure notification
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md
+      expr: sum(increase(velero_backup_failure_total[2m])) > 0
+      for: 1m
+      labels:
+        severity: info-warning
+        

--- a/resources/prometheusrule-alerts/node-alerts.yaml
+++ b/resources/prometheusrule-alerts/node-alerts.yaml
@@ -1,0 +1,125 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: prometheus-operator
+    role: alert-rules
+  name: prometheus-operator-custom-alerts-node.rules
+spec:
+  groups:
+  - name: node.rules
+    rules:
+    - alert: Node-Disk-Space-Low
+      expr: ((node_filesystem_avail_bytes * 100) / node_filesystem_size_bytes) < 10
+      for: 30m
+      labels:
+        severity: warning
+      annotations:
+        message: 'A node is reporting low disk space below 10%. Action is required on a node.'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#node-disk-space-low
+    - alert: CPU-High
+      expr: 100 - (avg by (instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 85
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        message: This device's CPU usage has exceeded the threshold with a value of {{ $value }}. Instance {{ $labels.instance }} CPU usage is dangerously high
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#cpu-high
+    - alert: CPU-Critical
+      expr: 100 - (avg by (instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 95
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        message: This device's CPU usage has exceeded the threshold with a value of {{ $value }}.Instance {{ $labels.instance }} CPU usage is critically high
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#cpu-critical
+    - alert: Memory-High
+      expr: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / (node_memory_MemTotal_bytes) * 100 > 80
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        message: '{{ $labels.instance }} has high memory usage for than 5 minutes. Instance {{ $labels.instance }} memory has high usage.'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#memory-high
+    - alert: Memory-Critical
+      expr: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / (node_memory_MemTotal_bytes) * 100 > 95
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        message: '{{ $labels.instance }} has high memory usage for than 5 minutes. Instance {{ $labels.instance }} memory has critically high usage.'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#memory-critical 
+    - alert: External-DNSDown
+      expr: kube_deployment_status_replicas_available{deployment="external-dns"} == 0
+      for: 5m
+      labels:
+        severity: warning
+      annotations: 
+        message: external-dns container has not been running in the namespace 'kube-system' for 5 minutes.
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#kubednsdown
+    - alert: NginxIngressPodDown
+      expr: kube_deployment_status_replicas_available{deployment="nginx-ingress-controller"} <6
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        message: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace. 1 or more nginx-ingress pods have been unavailable for 5 minutes'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#nginxingresspoddown
+    - alert: NginxIngressDown
+      expr: kube_deployment_status_replicas_available{deployment="nginx-ingress-controller"} == 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        descrition: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace. nginx-ingress has been down for 5 minutes'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#nginxingressdown
+    - alert: NginxAcmeIngressPodDown
+      expr: kube_deployment_status_replicas_available{deployment="nginx-ingress-acme-controller"} <6
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        message: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace. 1 or more nginx-acme-ingress pods have been unavailable for 5 minutes'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#nginxingresspoddown
+    - alert: NginxAcmeIngressDown
+      expr: kube_deployment_status_replicas_available{deployment="nginx-ingress-acme-controller"} == 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        descrition: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace. nginx-acme-ingress has been down for 5 minutes'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#nginxingressdown
+    - alert: RootVolUtilisation-High
+      expr: (node_filesystem_size_bytes {mountpoint="/"} - node_filesystem_avail_bytes {mountpoint="/"} ) / (node_filesystem_size_bytes {mountpoint="/"} ) * 100 >85
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        message: '{{ $labels.instance }} has exceeded the threshold of root volume utilisation with a value of {{ $value }}. Instance {{ $labels.instance }} root volume utilisation usage is high'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#root-volume-utilisation---high
+    - alert: RootVolUtilisation-Critical
+      expr: (node_filesystem_size_bytes {mountpoint="/"} - node_filesystem_avail_bytes {mountpoint="/"} ) / (node_filesystem_size_bytes {mountpoint="/"} ) * 100 >95
+      for: 1m
+      labels:
+        severity: critical
+      annotations:
+        message: '{{ $labels.instance }} has exceeded the threshold of root volume utilisation with a value of {{ $value }}. Instance {{ $labels.instance }} root volume utilisation usage is critically high'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#root-volume-utilisation---critical
+    - alert: LoadBalancer5XXCountHigh
+      expr: |-
+        count by (service) (increase(http_requests_total{code=~"5.*"}[15m]))  >=  10
+      for: 15m
+      labels:
+        severity: warning
+      annotations:
+        message: HTTPCode_Target_5XX_Count high for `{{$labels.service}}. HTTPCode_Target_5XX_Count high'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md
+    - alert: NginxConfigReloadFailure
+      annotations:
+        message: The Nginx Config has failed to reload for pod {{ $labels.pod }}
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#nginx-config-reload-failure
+      expr: nginx_ingress_controller_config_last_reload_successful == 0
+      for: 1m
+      labels:
+        severity: critical
+        

--- a/templates/oauth2-proxy.yaml.tpl
+++ b/templates/oauth2-proxy.yaml.tpl
@@ -1,0 +1,54 @@
+#
+# This is a redacted version of the upstream values.yaml file found here:
+# https://github.com/helm/charts/blob/dea84cfd139f0e7bd7721abfa53e4853c1379c0a/stable/oauth2-proxy/values.yaml
+#
+
+config:
+  clientID: "${client_id}"
+  clientSecret: "${client_secret}"
+  cookieSecret: "${cookie_secret}"
+  # Custom configuration file: oauth2_proxy.cfg
+  # configFile: |-
+  #   pass_basic_auth = false
+  #   pass_access_token = true
+  configFile: ""
+
+extraArgs:
+  provider: oidc
+  oidc-issuer-url: ${issuer_url}
+  email-domain: "*"
+  upstream: "${upstream}"
+  http-address: "0.0.0.0:4180"
+  skip-auth-regex: "${exclude_paths}"
+  cookie-expire: "7h"
+  skip-provider-button: true
+  pass-basic-auth: "false"
+  pass-host-header: "false"
+
+ingress:
+  enabled: true
+  path: /
+  hosts:
+    - "${hostname}"
+  tls:
+    - hosts:
+      - "${hostname}"
+
+  # annotations:
+  #   kubernetes.io/ingress.class: nginx
+  #   kubernetes.io/tls-acme: "true"
+
+  # annotations:
+  #   kubernetes.io/ingress.class: nginx
+  #   kubernetes.io/tls-acme: "true"
+  tls:
+    - hosts:
+      - "${hostname}"
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 300Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 300Mi

--- a/templates/prometheus-operator.yaml.tpl
+++ b/templates/prometheus-operator.yaml.tpl
@@ -1,0 +1,364 @@
+# Default values for prometheus-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+## Create default rules for monitoring the cluster
+##
+defaultRules:
+  create: true
+  rules:
+    general: false
+    kubernetesApps: false
+
+## Configuration for alertmanager
+## ref: https://prometheus.io/docs/alerting/alertmanager/
+##
+alertmanager:
+  ## Alertmanager configuration directives
+  ## ref: https://prometheus.io/docs/alerting/configuration/#configuration-file
+  ##      https://prometheus.io/webtools/alerting/routing-tree-editor/
+  ##
+  config:
+    global:
+      resolve_timeout: 5m
+    route:
+      group_by: ['alertname', 'job']
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 12h
+      receiver: 'null'
+      routes:
+      - match:
+          alertname: KubeQuotaExceeded
+        receiver: 'null'
+      - match:
+          alertname: CPUThrottlingHigh
+        receiver: 'null'
+      - match:
+          alertname: DeadMansSwitch
+        receiver: 'null'
+      - match:
+          alertname: DeploymentReplicasAreOutdated
+        receiver: 'null'
+      - match:
+          alertname: PodIsRestartingFrequently
+        receiver: 'null'
+      - match:
+          alertname: KubePersistentVolumeFullInFourDays
+        receiver: 'null'
+      - match:
+          alertname: PrometheusTargetScrapesDuplicate
+        receiver: 'null'
+      
+      - match:
+          severity: critical
+        receiver: pager-duty-high-priority
+      ${indent(6, alertmanager_routes)}
+    receivers:
+    - name: 'null'
+    # Add PagerDuty key to allow integration with a PD service.
+    - name: 'pager-duty-high-priority'
+      pagerduty_configs:
+      - service_key: "${ pagerduty_config }"
+    ${indent(4, alertmanager_receivers)}
+    templates:
+    - '/etc/alertmanager/config/cp-slack-templates.tmpl'
+
+  ## Alertmanager template files to format alerts
+  ## ref: https://prometheus.io/docs/alerting/notifications/
+  ##      https://prometheus.io/docs/alerting/notification_examples/
+  ##
+  templateFiles:
+    cp-slack-templates.tmpl: |-
+      {{ define "slack.cp.title" -}}
+        [{{ .Status | toUpper -}}
+        {{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{- end -}}
+        ] {{ template "__alert_severity_prefix_title" . }} {{ .CommonLabels.alertname }}
+      {{- end }}
+
+      {{/* The test to display in the alert */}}
+      {{ define "slack.cp.text" -}}
+        {{ range .Alerts }}
+            *Alert:* {{ .Annotations.message}}
+            *Details:*
+            {{ range .Labels.SortedPairs }} - *{{ .Name }}:* `{{ .Value }}`
+            {{ end }}
+            *-----*
+          {{ end }}
+      {{- end }}
+
+      {{ define "__alert_silence_link" -}}
+        {{ .ExternalURL }}/#/silences/new?filter=%7B
+        {{- range .CommonLabels.SortedPairs -}}
+          {{- if ne .Name "alertname" -}}
+            {{- .Name }}%3D"{{- .Value -}}"%2C%20
+          {{- end -}}
+        {{- end -}}
+          alertname%3D"{{ .CommonLabels.alertname }}"%7D
+      {{- end }}
+
+      {{ define "__alert_severity_prefix" -}}
+          {{ if ne .Status "firing" -}}
+          :white_check_mark:
+          {{- else if eq .Labels.severity "critical" -}}
+          :fire:
+          {{- else if eq .Labels.severity "warning" -}}
+          :warning:
+          {{- else -}}
+          :question:
+          {{- end }}
+      {{- end }}
+
+      {{ define "__alert_severity_prefix_title" -}}
+          {{ if ne .Status "firing" -}}
+          :white_check_mark:
+          {{- else if eq .CommonLabels.severity "critical" -}}
+          :fire:
+          {{- else if eq .CommonLabels.severity "warning" -}}
+          :warning:
+          {{- else if eq .CommonLabels.severity "info" -}}
+          :information_source:
+          {{- else if eq .CommonLabels.status_icon "information" -}}
+          :information_source:
+          {{- else -}}
+          :question:
+          {{- end }}
+      {{- end }}
+
+  ## Settings affecting alertmanagerSpec
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#alertmanagerspec
+  ##
+  alertmanagerSpec:
+   ## Log level for Alertmanager to be configured with.
+    ##
+    logLevel: info
+
+    ## Storage is the definition of how storage will be used by the Alertmanager instances.
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/storage.md
+    ##
+    storage:
+    volumeClaimTemplate:
+      spec:
+        storageClassName: default
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi
+      selector: {}
+
+    ## 	The external URL the Alertmanager instances will be available under. This is necessary to generate correct URLs. This is necessary if Alertmanager is not served from root of a DNS name.	string	false
+    ##
+    externalUrl: "${ alertmanager_ingress }"
+
+## Using default values from https://github.com/helm/charts/blob/master/stable/grafana/values.yaml
+##
+grafana:
+  enabled: true
+
+  adminUser: "${ random_username }"
+  adminPassword: "${ random_password }"
+
+  ## Pod Annotations
+  podAnnotations: 
+    iam.amazonaws.com/role: "${ grafana_pod_annotation }"
+
+  ingress:
+    ## If true, Prometheus Ingress will be created
+    ##
+    enabled: true
+
+    hosts:
+    - "${ grafana_ingress }"
+
+    tls:
+      - hosts:
+        - "${ grafana_ingress }"
+
+  env:
+    GF_SERVER_ROOT_URL: "${ grafana_root }"
+    GF_ANALYTICS_REPORTING_ENABLED: "false"
+    GF_AUTH_DISABLE_LOGIN_FORM: "true"
+    GF_USERS_ALLOW_SIGN_UP: "false"
+    GF_USERS_AUTO_ASSIGN_ORG_ROLE: "Viewer"
+    GF_USERS_VIEWERS_CAN_EDIT: "true"
+    GF_SMTP_ENABLED: "false"
+    GF_AUTH_GENERIC_OAUTH_ENABLED: "true"
+    GF_AUTH_GENERIC_OAUTH_ALLOW_SIGN_UP: "true"
+    GF_AUTH_GENERIC_OAUTH_NAME: "Auth0"
+    GF_AUTH_GENERIC_OAUTH_SCOPES: "openid profile email"
+
+  envFromSecret: "grafana-env"
+
+  serverDashboardConfigmaps:
+    - grafana-user-dashboards
+
+  sidecar:
+    dashboards:
+      enabled: true
+      label: grafana_dashboard
+      searchNamespace: ALL
+    datasources:
+      enabled: true
+      label: grafana_datasource
+
+  ## Configure additional grafana datasources
+  ## ref: http://docs.grafana.org/administration/provisioning/#datasources
+  additionalDataSources:
+  - name: Cloudwatch
+    type: cloudwatch
+    editable: true
+    access: proxy
+    jsonData:
+      authType: arn
+      defaultRegion: eu-west-2
+      assumeRoleArn: "${ grafana_assumerolearn }"
+    orgId: 1
+    version: 1
+
+## Component scraping coreDns. Use either this or kubeDns
+##
+coreDns:
+  enabled: false
+
+## Component scraping kubeDns. Use either this or coreDns
+##
+kubeDns:
+  enabled: true
+
+## Component scraping etcd
+##
+kubeEtcd:
+  enabled: true
+
+## Component scraping kube scheduler
+##
+kubeScheduler:
+  enabled: true
+
+  ## If using kubeScheduler.endpoints only the port and targetPort are used
+  ##
+  service:
+    selector:
+      k8s-app: kube-scheduler
+
+## Component scraping the kube controller manager
+##
+kubeControllerManager:
+  enabled: true
+
+  ## If using kubeControllerManager.endpoints only the port and targetPort are used
+  ##
+  service:
+    selector:
+      k8s-app: kube-controller-manager
+
+## Component scraping kube state metrics
+##
+kubeStateMetrics:
+  enabled: true
+
+## Configuration for kube-state-metrics subchart
+##
+kube-state-metrics:
+  image:
+    tag: v1.7.0
+
+## Manages Prometheus and Alertmanager components
+##
+prometheusOperator:
+  enabled: true
+
+  tlsProxy:
+    enabled: false
+
+  admissionWebhooks:
+    enabled: false
+
+  ## Deploy CRDs used by Prometheus Operator.
+  ##
+  createCustomResource: true
+
+  ## Attempt to clean up CRDs created by Prometheus Operator.
+  ##
+  cleanupCustomResource: true
+
+## Deploy a Prometheus instance
+##
+prometheus:
+
+  enabled: true
+
+  ## Settings affecting prometheusSpec
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+  ##
+  prometheusSpec:
+
+    ## External URL at which Prometheus will be reachable.
+    ##
+    externalUrl: "${ prometheus_ingress }"
+
+    ## Namespaces to be selected for PrometheusRules discovery.
+    ## If unspecified, only the same namespace as the Prometheus object is in is used.
+    ##
+    ruleNamespaceSelector:
+      any: true
+
+    ## Rules CRD selector
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/design.md
+    ## If unspecified the release `app` and `release` will be used as the label selector
+    ## to load rules
+    ##
+    ruleSelector:
+      any: true
+    ## Example which select all prometheusrules resources
+    ## with label "prometheus" with values any of "example-rules" or "example-rules-2"
+    # ruleSelector:
+    #   matchExpressions:
+    #     - key: prometheus
+    #       operator: In
+    #       values:
+    #         - example-rules
+    #         - example-rules-2
+    #
+    ## Example which select all prometheusrules resources with label "role" set to "example-rules"
+    # ruleSelector:
+    #   matchLabels:
+    #     role: example-rules
+
+    ## serviceMonitorSelector will limit which servicemonitors are used to create scrape
+    ## configs in Prometheus. See serviceMonitorSelectorUseHelmLabels
+    ##
+    serviceMonitorSelector:
+      any: true
+
+    # serviceMonitorSelector: {}
+    #   matchLabels:
+    #     prometheus: somelabel
+
+    ## serviceMonitorNamespaceSelector will limit namespaces from which serviceMonitors are used to create scrape
+    ## configs in Prometheus. By default all namespaces will be used
+    ##
+    serviceMonitorNamespaceSelector:
+      any: true
+
+    ## How long to retain metrics
+    ##
+    retention: 30d
+
+    podMetadata:
+      annotations:
+        iam.amazonaws.com/role: "${monitoring_aws_role}"
+
+    ## Prometheus StorageSpec for persistent data
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/storage.md
+    ##
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: default
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 750Gi
+        selector: {}
+

--- a/templates/prometheus-operator.yaml.tpl
+++ b/templates/prometheus-operator.yaml.tpl
@@ -345,10 +345,6 @@ prometheus:
     ##
     retention: 30d
 
-    podMetadata:
-      annotations:
-        iam.amazonaws.com/role: "${monitoring_aws_role}"
-
     ## Prometheus StorageSpec for persistent data
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/storage.md
     ##

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,29 @@
+
+variable "alertmanager_slack_receivers" {
+  description = "A list of configuration values for Slack receivers"
+  type        = list
+}
+
+
+variable "iam_role_nodes" {
+  description = "Nodes IAM role ARN in order to create the KIAM/Kube2IAM"
+  type        = string
+}
+
+variable "pagerduty_config" {
+  description = "Add PagerDuty key to allow integration with a PD service."
+}
+
+variable "dependence_deploy" {
+  description = "Deploy Module dependences in order to be executed."
+}
+
+variable "dependence_opa" {
+  description = "OPA module dependences in order to be executed."
+}
+
+variable "enable_thanos" {
+  description = "Enable or not Thanos"
+  default     = false
+  type        = bool
+}

--- a/variables.tf
+++ b/variables.tf
@@ -22,8 +22,15 @@ variable "dependence_opa" {
   description = "OPA module dependences in order to be executed."
 }
 
-variable "enable_thanos" {
-  description = "Enable or not Thanos"
+variable "enable_ecr_exporter" {
+  description = "Enable or not ECR exporter"
   default     = false
   type        = bool
 }
+
+variable "enable_cloudwatch_exporter" {
+  description = "Enable or not Cloudwatch exporter"
+  default     = false
+  type        = bool
+}
+


### PR DESCRIPTION
In order to achieve the migration of the Prometheus resources to their own terraform module we had to create a new repo (this one) and move all resources from [cloud-platform-components](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/prometheus.tf) to here. 
