### PR TITLE
Avoid CRD creation for Prometheus Helm Chart.

### DIFF
--- a/templates/prometheus-operator.yaml.tpl
+++ b/templates/prometheus-operator.yaml.tpl
@@ -276,7 +276,7 @@ prometheusOperator:
 
   ## Deploy CRDs used by Prometheus Operator.
   ##
-  createCustomResource: true
+  createCustomResource: false
 
   ## Attempt to clean up CRDs created by Prometheus Operator.
   ##


### PR DESCRIPTION
 This allows us to manage the CRD by ourself instead of the helm chart. With this, we avoid deleting CRD and losing CRD resources