### PR TITLE
Thanos Helm Chart

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,3 +14,9 @@ data "helm_repository" "cloud_platform" {
   name = "cloud-platform"
   url  = "https://ministryofjustice.github.io/cloud-platform-helm-charts"
 }
+
+data "helm_repository" "banzaicloud" {
+  name = "banzaicloud-stable"
+  url  = "https://kubernetes-charts.banzaicloud.com"
+}
+

--- a/prometheus.tf
+++ b/prometheus.tf
@@ -126,6 +126,7 @@ resource "helm_release" "prometheus_operator" {
     grafana_pod_annotation = aws_iam_role.grafana_datasource.name
     grafana_assumerolearn  = aws_iam_role.grafana_datasource.arn
     monitoring_aws_role    = aws_iam_role.monitoring.name
+    clusterName            = terraform.workspace
   })]
 
   # Depends on Helm being installed

--- a/templates/prometheus-operator.yaml.tpl
+++ b/templates/prometheus-operator.yaml.tpl
@@ -293,6 +293,11 @@ prometheus:
   ##
   prometheusSpec:
 
+    ## External labels to add to any time series or alerts when communicating with external systems
+    ##    
+    externalLabels:
+      clusterName: "${clusterName}"
+
     ## External URL at which Prometheus will be reachable.
     ##
     externalUrl: "${ prometheus_ingress }"

--- a/templates/thanos-values.yaml.tpl
+++ b/templates/thanos-values.yaml.tpl
@@ -1,0 +1,15 @@
+
+store:
+  annotations:
+    iam.amazonaws.com/role: "${monitoring_aws_role}"
+
+compact:
+  enabled: ${enabled_compact}
+  annotations:
+    iam.amazonaws.com/role: "${monitoring_aws_role}"
+
+bucket:
+  annotations:
+    iam.amazonaws.com/role: "${monitoring_aws_role}"
+
+objstoreSecretOverride: thanos-objstore-config

--- a/thanos.tf
+++ b/thanos.tf
@@ -70,6 +70,7 @@ resource "helm_release" "thanos" {
   version   = "0.3.18"
 
   values = [templatefile("${path.module}/templates/thanos-values.yaml.tpl", {
+    enabled_compact        = var.enable_thanos_compact
     monitoring_aws_role    = aws_iam_role.monitoring.name
   })]
 

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,6 @@ variable "alertmanager_slack_receivers" {
   type        = list
 }
 
-
 variable "iam_role_nodes" {
   description = "Nodes IAM role ARN in order to create the KIAM/Kube2IAM"
   type        = string
@@ -34,3 +33,8 @@ variable "enable_cloudwatch_exporter" {
   type        = bool
 }
 
+variable "enable_thanos_compact" {
+  description = "Enable or not Thanos Compact - not semantically concurrency safe and must be deployed as a singleton against a bucket"
+  default     = false
+  type        = bool
+}


### PR DESCRIPTION
Thanos sidecar was added in our last release of (0.0.5) Prometheus terraform module. The sidecar allows us to push metrics to S3 bucket, only that! What if we want to visualise these metrics from the S3 bucket? If we want to compact them? If we want to create alerts/rules from them? 

This PR installs a Thanos Helm Chart (developed by banzaicloud) which deploys another Thanos components: Bucket, Check, Compactor, Query, Rule

For the time being these components are not going to be exposed, they will reside/live inside the cluster and the way how to access them will be through port-forward. Later on, in future releases, Ingresses and proxy-auths will be set up.

Another important change included is externalLabels for Prometheus. These labels allow us to differentiate Prometheuses from each other, which at the moment is causing noise for compact component (because it thinks metrics are from the same cluster even if they are different clusters), more information: https://github.com/thanos-io/thanos/blob/master/docs/components/compact.md#groups

This was tested in a cluster called cp-0403-2039