### PR TITLE
Updated retention period to 1d

### DIFF
--- a/templates/prometheus-operator.yaml.tpl
+++ b/templates/prometheus-operator.yaml.tpl
@@ -348,7 +348,7 @@ prometheus:
 
     ## How long to retain metrics
     ##
-    retention: 30d
+    retention: 1d
 
     podMetadata:
       annotations:


### PR DESCRIPTION
We are experiencing memory problems with Prometheus, because of this we're updating retention to 24h. The metrics are saved in S3 using Thanos. 