### PR TITLE
Added forgotten cloudwatch values file

### DIFF
--- a/resources/cloudwatch-exporter.yaml
+++ b/resources/cloudwatch-exporter.yaml
@@ -1,0 +1,237 @@
+# Values file for Helm chart stable/prometheus-cloudwatch-exporter
+# This YAML-formatted file will be called by Terraform.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: prom/cloudwatch-exporter
+  tag: cloudwatch_exporter-0.6.0
+  pullPolicy: IfNotPresent
+
+aws:
+  role:
+  # The name of a pre-created secret in which AWS credentials are stored. When
+  # set, aws_access_key_id is assumed to be in a field called access_key,
+  # aws_secret_access_key is assumed to be in a field called secret_key, and the
+  # session token, if it exists, is assumed to be in a field called
+  # security_token
+
+config: |-
+  # To add additional Cloudwatch metrics, please append this config list.
+  region: eu-west-2
+  period_seconds: 240
+  metrics:
+  # RDS Metrics
+  - aws_namespace: AWS/RDS
+    aws_metric_name: CPUUtilization
+    aws_dimensions: [DBInstanceIdentifier]
+ 
+  - aws_namespace: AWS/RDS
+    aws_metric_name: DatabaseConnections
+    aws_dimensions: [DBInstanceIdentifier]
+ 
+  - aws_namespace: AWS/RDS
+    aws_metric_name: FreeableMemory
+    aws_dimensions: [DBInstanceIdentifier]
+
+  - aws_namespace: AWS/RDS
+    aws_metric_name: FreeStorageSpace
+    aws_dimensions: [DBInstanceIdentifier]
+
+  - aws_namespace: AWS/RDS
+    aws_metric_name: ReadIOPS
+    aws_dimensions: [DBInstanceIdentifier]
+ 
+  - aws_namespace: AWS/RDS
+    aws_metric_name: ReadLatency
+    aws_dimensions: [DBInstanceIdentifier]
+
+  - aws_namespace: AWS/RDS
+    aws_metric_name: WriteIOPS
+    aws_dimensions: [DBInstanceIdentifier]
+
+  - aws_namespace: AWS/RDS
+    aws_metric_name: WriteLatency
+    aws_dimensions: [DBInstanceIdentifier]
+
+    # S3 Metrics
+  - aws_namespace: AWS/S3
+    aws_metric_name: BucketSizeBytes
+    aws_dimensions: [BucketName, StorageType]
+ 
+  - aws_namespace: AWS/S3
+    aws_metric_name: NumberOfObjects
+    aws_dimensions: [BucketName, StorageType]
+
+    # SQS Metrics
+  - aws_namespace: AWS/SQS
+    aws_metric_name: ApproximateAgeOfOldestMessage
+    aws_dimensions: [QueueName]
+
+  - aws_namespace: AWS/SQS
+    aws_metric_name: ApproximateNumberOfMessagesDelayed
+    aws_dimensions: [QueueName]
+
+  - aws_namespace: AWS/SQS
+    aws_metric_name: ApproximateNumberOfMessagesNotVisible
+    aws_dimensions: [QueueName]
+
+  - aws_namespace: AWS/SQS
+    aws_metric_name: ApproximateNumberOfMessagesVisible
+    aws_dimensions: [QueueName]
+
+  - aws_namespace: AWS/SQS
+    aws_metric_name: NumberOfEmptyReceives
+    aws_dimensions: [QueueName]
+
+  - aws_namespace: AWS/SQS
+    aws_metric_name: NumberOfMessagesDeleted
+    aws_dimensions: [QueueName]
+
+  - aws_namespace: AWS/SQS
+    aws_metric_name: NumberOfMessagesReceived
+    aws_dimensions: [QueueName]
+
+  - aws_namespace: AWS/SQS
+    aws_metric_name: NumberOfMessagesSent
+    aws_dimensions: [QueueName]
+
+  - aws_namespace: AWS/SQS
+    aws_metric_name: SentMessageSize
+    aws_dimensions: [QueueName]
+    
+    # SNS Metrics
+  - aws_namespace: AWS/SNS
+    aws_metric_name: NumberOfMessagesPublished
+    aws_dimensions: [TopicName]
+
+  - aws_namespace: AWS/SNS
+    aws_metric_name: NumberOfNotificationsDelivered 
+    aws_dimensions: [TopicName]
+
+  - aws_namespace: AWS/SNS
+    aws_metric_name: NumberOfNotificationsFailed 
+    aws_dimensions: [TopicName]
+
+  - aws_namespace: AWS/SNS
+    aws_metric_name: NumberOfNotificationsFilteredOut
+    aws_dimensions: [TopicName]
+
+  - aws_namespace: AWS/SNS
+    aws_metric_name: NumberOfNotificationsFilteredOut-NoMessageAttributes
+    aws_dimensions: [TopicName]
+
+  - aws_namespace: AWS/SNS
+    aws_metric_name: NumberOfNotificationsFilteredOut-InvalidAttributes
+    aws_dimensions: [TopicName]
+    
+  - aws_namespace: AWS/SNS
+    aws_metric_name: PublishSize
+    aws_dimensions: [TopicName]
+
+    # ElastiCache Redis Metrics
+  - aws_namespace: AWS/ElastiCache
+    aws_metric_name: CPUUtilization
+
+  - aws_namespace: AWS/ElastiCache
+    aws_metric_name: FreeableMemory
+ 
+  - aws_namespace: AWS/ElastiCache
+    aws_metric_name: NetworkBytesIn
+
+  - aws_namespace: AWS/ElastiCache
+    aws_metric_name: NetworkBytesOut
+ 
+  - aws_namespace: AWS/ElastiCache
+    aws_metric_name: NetworkPacketsIn
+ 
+  - aws_namespace: AWS/ElastiCache
+    aws_metric_name: NetworkPacketsOut
+ 
+    # DynamoDB Metrics   
+  - aws_namespace: AWS/DynamoDB
+    aws_metric_name: ReturnedBytes
+    aws_dimensions: [TableName]
+   
+  - aws_namespace: AWS/DynamoDB
+    aws_metric_name: ReturnedItemCount
+    aws_dimensions: [TableName]
+   
+  - aws_namespace: AWS/DynamoDB
+    aws_metric_name: ReturnedRecordsCount
+    aws_dimensions: [TableName]
+ 
+  - aws_namespace: AWS/DynamoDB
+    aws_metric_name: SuccessfulRequestLatency
+    aws_dimensions: [TableName]
+ 
+  - aws_namespace: AWS/DynamoDB
+    aws_metric_name: SystemErrors
+    aws_dimensions: [TableName]
+
+  - aws_namespace: AWS/DynamoDB
+    aws_metric_name: TransactionConflict
+    aws_dimensions: [TableName]
+
+  - aws_namespace: AWS/DynamoDB
+    aws_metric_name: UserErrors
+    aws_dimensions: [TableName]
+
+    # MQ Broker Metrics
+  - aws_namespace: AWS/AmazonMQ
+    aws_metric_name: CpuUtilization
+    aws_dimensions: [Broker]
+
+  - aws_namespace: AWS/AmazonMQ
+    aws_metric_name: CurrentConnectionsCount
+    aws_dimensions: [Broker]
+
+  - aws_namespace: AWS/AmazonMQ
+    aws_metric_name: OpenTransactionCount
+    aws_dimensions: [Broker]
+ 
+  - aws_namespace: AWS/AmazonMQ
+    aws_metric_name: StorePercentUsage
+    aws_dimensions: [Broker]
+
+  - aws_namespace: AWS/AmazonMQ
+    aws_metric_name: TotalConsumerCount
+    aws_dimensions: [Broker]
+ 
+  - aws_namespace: AWS/AmazonMQ
+    aws_metric_name: TotalMessageCount
+    aws_dimensions: [Broker]
+ 
+  - aws_namespace: AWS/AmazonMQ
+    aws_metric_name: TotalProducerCount
+    aws_dimensions: [Broker] 
+
+  # Elasticsearch Metrics
+  - aws_namespace: AWS/ES
+    aws_metric_name: ClusterStatus.green
+    aws_dimensions: [DomainName,ClientId]
+    
+  - aws_namespace: AWS/ES
+    aws_metric_name: ClusterStatus.yellow
+    aws_dimensions: [DomainName,ClientId]
+
+  - aws_namespace: AWS/ES
+    aws_metric_name: ClusterStatus.red
+    aws_dimensions: [DomainName,ClientId]
+
+
+serviceMonitor:
+  # When set true then use a ServiceMonitor to configure scraping
+  enabled: true
+  # Set the namespace the ServiceMonitor should be deployed
+  namespace: monitoring
+  # Set how frequently Prometheus should scrape
+  interval: 60s
+  # Set path to cloudwatch-exporter telemtery-path
+  telemetryPath: /metrics
+  # Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
+  labels:
+    app: prometheus-cloudwatch-exporter
+  # Set timeout for scrape
+  timeout: 30s


### PR DESCRIPTION
This module is referencing a file that doesn't exist (CloudWatch values file), [check it here](https://github.com/ministryofjustice/cloud-platform-terraform-prometheus/blob/master/cloudwatch-exporter.tf#L13). 

This PR adds the missing file. 