### PR TITLE
Implemented `path.module` for a reference

### DIFF
--- a/cloudwatch-exporter.tf
+++ b/cloudwatch-exporter.tf
@@ -10,7 +10,7 @@ resource "helm_release" "cloudwatch_exporter" {
   chart     = "stable/prometheus-cloudwatch-exporter"
 
   values = [
-    file("./resources/cloudwatch-exporter.yaml"),
+    file("${path.module}/resources/cloudwatch-exporter.yaml"),
   ]
 
   set {


### PR DESCRIPTION
Because now we are using Prometheus/CloudWatch from within a module we must use `path.module` to reference files.