### PR TITLE
Added NodeAffinity to Prometheus and ran terraform format

### DIFF
--- a/cloudwatch-exporter.tf
+++ b/cloudwatch-exporter.tf
@@ -3,7 +3,7 @@
 # Ref: https://github.com/helm/charts/blob/master/stable/prometheus-cloudwatch-exporter/values.yaml
 
 resource "helm_release" "cloudwatch_exporter" {
-  count     = var.enable_cloudwatch_exporter ? 1 : 0
+  count = var.enable_cloudwatch_exporter ? 1 : 0
 
   name      = "cloudwatch-exporter"
   namespace = kubernetes_namespace.monitoring.id

--- a/ecr-exporter.tf
+++ b/ecr-exporter.tf
@@ -5,7 +5,7 @@
 ################
 
 resource "helm_release" "ecr_exporter" {
-  count      = var.enable_ecr_exporter ? 1 : 0
+  count = var.enable_ecr_exporter ? 1 : 0
 
   name       = "ecr-exporter"
   namespace  = kubernetes_namespace.monitoring.id

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 
 output "helm_prometheus_operator_status" {
-    value = helm_release.prometheus_operator.status
+  value = helm_release.prometheus_operator.status
 }

--- a/prometheus.tf
+++ b/prometheus.tf
@@ -114,19 +114,20 @@ resource "helm_release" "prometheus_operator" {
   version   = "8.7.0"
 
   values = [templatefile("${path.module}/templates/prometheus-operator.yaml.tpl", {
-    alertmanager_ingress   = local.alertmanager_ingress
-    grafana_ingress        = local.grafana_ingress
-    grafana_root           = local.grafana_root
-    pagerduty_config       = var.pagerduty_config
-    alertmanager_routes    = "${join("", data.template_file.alertmanager_routes.*.rendered)}"
-    alertmanager_receivers = "${join("", data.template_file.alertmanager_receivers.*.rendered)}"
-    prometheus_ingress     = local.prometheus_ingress
-    random_username        = random_id.username.hex
-    random_password        = random_id.password.hex
-    grafana_pod_annotation = aws_iam_role.grafana_datasource.name
-    grafana_assumerolearn  = aws_iam_role.grafana_datasource.arn
-    monitoring_aws_role    = aws_iam_role.monitoring.name
-    clusterName            = terraform.workspace
+    alertmanager_ingress       = local.alertmanager_ingress
+    grafana_ingress            = local.grafana_ingress
+    grafana_root               = local.grafana_root
+    pagerduty_config           = var.pagerduty_config
+    alertmanager_routes        = "${join("", data.template_file.alertmanager_routes.*.rendered)}"
+    alertmanager_receivers     = "${join("", data.template_file.alertmanager_receivers.*.rendered)}"
+    prometheus_ingress         = local.prometheus_ingress
+    random_username            = random_id.username.hex
+    random_password            = random_id.password.hex
+    grafana_pod_annotation     = aws_iam_role.grafana_datasource.name
+    grafana_assumerolearn      = aws_iam_role.grafana_datasource.arn
+    monitoring_aws_role        = aws_iam_role.monitoring.name
+    clusterName                = terraform.workspace
+    enable_prometheus_affinity = var.enable_prometheus_affinity
   })]
 
   # Depends on Helm being installed

--- a/templates/prometheus-operator.yaml.tpl
+++ b/templates/prometheus-operator.yaml.tpl
@@ -354,6 +354,21 @@ prometheus:
       annotations:
         iam.amazonaws.com/role: "${monitoring_aws_role}"
 
+    %{ if enable_prometheus_affinity ~}
+    ## Assign custom affinity rules to the prometheus instance
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+    ##
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: beta.kubernetes.io/instance-type
+              operator: In
+              values:
+              - r5.2xlarge
+    %{ endif ~}
+
     ## Prometheus StorageSpec for persistent data
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/storage.md
     ##

--- a/thanos.tf
+++ b/thanos.tf
@@ -9,7 +9,7 @@ data "aws_iam_policy_document" "monitoring_assume" {
 
     principals {
       type        = "AWS"
-      identifiers = [ var.iam_role_nodes ]
+      identifiers = [var.iam_role_nodes]
     }
   }
 }
@@ -70,11 +70,11 @@ resource "helm_release" "thanos" {
   version   = "0.3.18"
 
   values = [templatefile("${path.module}/templates/thanos-values.yaml.tpl", {
-    enabled_compact        = var.enable_thanos_compact
-    monitoring_aws_role    = aws_iam_role.monitoring.name
+    enabled_compact     = var.enable_thanos_compact
+    monitoring_aws_role = aws_iam_role.monitoring.name
   })]
 
-  depends_on = [ helm_release.prometheus_operator ]
+  depends_on = [helm_release.prometheus_operator]
 
   lifecycle {
     ignore_changes = [keyring]

--- a/variables.tf
+++ b/variables.tf
@@ -38,3 +38,9 @@ variable "enable_thanos_compact" {
   default     = false
   type        = bool
 }
+
+variable "enable_prometheus_affinity" {
+  description = "Enable or not Prometheus node affinity (check helm values for the expressions)"
+  default     = false
+  type        = bool
+}


### PR DESCRIPTION
Added nodeAffinity capabilities to Prometheus in order to specify in which instance class it needs to be deployed. This requirement comes from Prometheus resources problem we are having. 

It applies some format to the terraform files (`terraform fmt`)